### PR TITLE
Build nGraph using MXnet's MKLDNN library.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,8 @@ ifeq ($(USE_MKLDNN), 1)
 	MKLDNNROOT = $(ROOTDIR)/3rdparty/mkldnn/build/install
 	MKLROOT = $(ROOTDIR)/3rdparty/mkldnn/build/install
 	export USE_MKLML = 1
+	MKLDNN_INCLUDE_DIR = $(MKLDNNROOT)/include
+	MKLDNN_LIB_DIR = $(MKLDNNROOT)/lib
 endif
 
 include $(TPARTYDIR)/mshadow/make/mshadow.mk

--- a/tests/cpp/unittest.mk
+++ b/tests/cpp/unittest.mk
@@ -62,7 +62,8 @@ build/tests/cpp/engine/%.o : tests/cpp/engine/%.cc | mkldnn
 	$(CXX) -c -std=c++11 $(TEST_CFLAGS) -I$(GTEST_INC) -o build/tests/cpp/engine/$*.o $(filter %.cc %.a, $^)
 
 $(TEST): $(TEST_OBJ) lib/libmxnet.so gtest.a
-	$(CXX) -std=c++11 $(TEST_CFLAGS) -I$(GTEST_INC) -o $@ $^ $(TEST_LDFLAGS)
+	$(CXX) -std=c++11 $(TEST_CFLAGS) -I$(GTEST_INC) -o $@ $^ $(TEST_LDFLAGS) \
+	   $(NGRAPH_LDFLAGS_FOR_CPP_UNIT_TESTS_PROG)
 
 runtest: $(TEST)
 	LD_LIBRARY_PATH=$(shell pwd)/lib:$(LD_LIBRARY_PATH) $(TEST)


### PR DESCRIPTION
When MXnet is built with MKLDNN support _and_ nGraph support, use MXnet's instance of MKLDNN.